### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/stryker.yml
+++ b/.github/workflows/stryker.yml
@@ -1,4 +1,6 @@
 name: CI Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bmordue/miniap/security/code-scanning/11](https://github.com/bmordue/miniap/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the workflow's operations, such as checking out the repository and running tests. No write permissions are required for this workflow.

The `permissions` block will be added immediately after the `name` field in the workflow file to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
